### PR TITLE
Fix apps/Makefile for non-debian systems

### DIFF
--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -19,7 +19,7 @@ all-local:
 	$(PYTHON) setup.py build
 
 install-exec-local:
-	$(PYTHON) setup.py install --prefix=$$DESTDIR$(prefix) --install-layout=deb
+	$(PYTHON) setup.py install --prefix=$$DESTDIR$(prefix)
 
 clean-local:
 	rm -rf build


### PR DESCRIPTION
--install-layout=deb prevents building for general systems. We require a branch where we can pull code from automatically that will work.